### PR TITLE
fix(protoc-gen-http-swagger): resolve staticcheck lint errors

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           version: latest
           working-directory: ${{ matrix.workdir }}
-          args: -E gofumpt --timeout 10m
+          args: --timeout 5m

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,16 +4,16 @@ on: [ pull_request ]
 
 jobs:
   compliant:
-    runs-on: [ self-hosted, X64 ]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check License Header
         uses: apache/skywalking-eyes/header@v0.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: typos-action
+      - name: Check Spell
         uses: crate-ci/typos@master
 
   resolve-modules:
@@ -23,7 +23,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set execute permission for resolve-modules.sh
         run: chmod +x ./hack/resolve-modules.sh
@@ -38,11 +38,10 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: ${{ matrix.workdir }}
           args: -E gofumpt --timeout 10m
-          skip-pkg-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,36 +1,16 @@
-# Options for analysis running.
-run:
-  # include `vendor` `third_party` `testdata` `examples` `Godeps` `builtin`
-  skip-dirs-use-default: true
-# output configuration options
-output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  formats: colored-line-number
-# All available settings of specific linters.
-# Refer to https://golangci-lint.run/usage/linters
-linters-settings:
-  gofumpt:
-    # Choose whether to use the extra rules.
-    # Default: false
-    extra-rules: true
-  govet:
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    disable:
-      - stdmethods
+version: "2"
 linters:
+  default: none
+  enable:
+    - govet
+    - ineffassign
+    - staticcheck
+    - unconvert
+    - unused
+formatters:
   enable:
     - gofumpt
     - goimports
-    - gofmt
-  disable:
-    - errcheck
-    - typecheck
-    - varcheck
-    - staticcheck
-issues:
-  exclude-use-default: true
-  exclude-files:
-    - ".*\\.mock\\.go$"
-  exclude-dirs:
-    - kitex_gen
+  settings:
+    gofumpt:
+      extra-rules: true

--- a/protoc-gen-http-swagger/generator/reflector.go
+++ b/protoc-gen-http-swagger/generator/reflector.go
@@ -74,10 +74,12 @@ func (r *OpenAPIReflector) formatMessageName(message protoreflect.MessageDescrip
 
 	name := r.getMessageName(message)
 	if !*r.conf.FQSchemaNaming {
-		if typeName == ".google.protobuf.Value" {
+		switch typeName {
+		case ".google.protobuf.Value":
 			name = consts.ProtobufValueName
-		} else if typeName == ".google.protobuf.Any" {
+		case ".google.protobuf.Any":
 			name = consts.ProtobufAnyName
+		default:
 		}
 	}
 
@@ -216,7 +218,7 @@ func (r *OpenAPIReflector) schemaOrReferenceForField(field protoreflect.FieldDes
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.EnumKind:
-		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)
+		kindSchema = wk.NewEnumSchema(r.conf.EnumType, field)
 
 	case protoreflect.BoolKind:
 		kindSchema = wk.NewBooleanSchema()

--- a/protoc-gen-rpc-swagger/generator/reflector.go
+++ b/protoc-gen-rpc-swagger/generator/reflector.go
@@ -74,10 +74,12 @@ func (r *OpenAPIReflector) formatMessageName(message protoreflect.MessageDescrip
 
 	name := r.getMessageName(message)
 	if !*r.conf.FQSchemaNaming {
-		if typeName == ".google.protobuf.Value" {
+		switch typeName {
+		case ".google.protobuf.Value":
 			name = consts.ProtobufValueName
-		} else if typeName == ".google.protobuf.Any" {
+		case ".google.protobuf.Any":
 			name = consts.ProtobufAnyName
+		default:
 		}
 	}
 
@@ -216,7 +218,7 @@ func (r *OpenAPIReflector) schemaOrReferenceForField(field protoreflect.FieldDes
 		kindSchema = wk.NewStringSchema()
 
 	case protoreflect.EnumKind:
-		kindSchema = wk.NewEnumSchema(*&r.conf.EnumType, field)
+		kindSchema = wk.NewEnumSchema(r.conf.EnumType, field)
 
 	case protoreflect.BoolKind:
 		kindSchema = wk.NewBooleanSchema()

--- a/thrift-gen-http-swagger/generator/openapi_gen.go
+++ b/thrift-gen-http-swagger/generator/openapi_gen.go
@@ -229,19 +229,19 @@ func (g *OpenAPIGenerator) getDocumentOption(obj interface{}) error {
 		return nil
 	}
 
-	if serviceOrStruct == consts.DocumentOptionServiceType {
+	switch serviceOrStruct {
+	case consts.DocumentOptionServiceType:
 		serviceDesc := g.fileDesc.GetServiceDescriptor(name)
 		if serviceDesc != nil {
-			err := utils.ParseServiceOption(serviceDesc, consts.OpenapiDocument, obj)
-			if err != nil {
+			if err := utils.ParseServiceOption(serviceDesc, consts.OpenapiDocument, obj); err != nil {
 				return err
 			}
 		}
-	} else if serviceOrStruct == consts.DocumentOptionStructType {
+
+	case consts.DocumentOptionStructType:
 		structDesc := g.fileDesc.GetStructDescriptor(name)
 		if structDesc != nil {
-			err := utils.ParseStructOption(structDesc, consts.OpenapiDocument, obj)
-			if err != nil {
+			if err := utils.ParseStructOption(structDesc, consts.OpenapiDocument, obj); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

fix(protoc-gen-http-swagger): 修复 staticcheck lint 错误

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: Fix the same staticcheck issues that were addressed in `protoc-gen-rpc-swagger` but missed in `protoc-gen-http-swagger`. This is a supplement to PR #18.
- QF1003: use tagged switch instead of if/else-if chain
- SA4001: remove redundant `*&` dereference

zh(optional): 修复 `protoc-gen-rpc-swagger` 中已处理但 `protoc-gen-http-swagger` 中遗漏的 staticcheck 问题，作为 PR #18 的补充。
- QF1003: 使用 tagged switch 替代 if/else-if 链
- SA4001: 移除多余的 `*&` 解引用

#### (Optional) Which issue(s) this PR fixes:

Supplements #18

#### (optional) The PR that updates user documentation:

N/A